### PR TITLE
Add images subcommand: disk-pressure image eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "clap",
  "futures",
  "go-parse-duration",
+ "rustix",
  "serial_test",
  "tabled",
  "thiserror",
@@ -267,6 +268,16 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -741,6 +752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +933,19 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.44", default-features = false, features = [
 clap = { version = "4.6.1", features = ["derive"] }
 futures = "0.3.32"
 go-parse-duration = "0.1.1"
+rustix = { version = "1.0.8", features = ["fs"] }
 tabled = "0.21.0"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,10 @@ use anyhow::Context;
 use bollard::Docker;
 use clap::{Args, Parser, Subcommand};
 use reaper::{
-    Filter, ReapContainersConfig, ReapNetworksConfig, ReapVolumesConfig, reap_containers,
-    reap_networks, reap_volumes,
+    Filter, ReapContainersConfig, ReapImagesConfig, ReapNetworksConfig, ReapVolumesConfig,
+    reap_containers, reap_images, reap_networks, reap_volumes,
 };
+use std::path::PathBuf;
 use tokio::time::{Duration, sleep};
 
 #[derive(Debug, Parser)]
@@ -40,6 +41,8 @@ enum Commands {
     Networks(NetworksArgs),
     /// Reap matching volumes.
     Volumes(VolumesArgs),
+    /// Reap unused images when disk usage exceeds a threshold.
+    Images(ImagesArgs),
 }
 
 #[derive(Debug, Args)]
@@ -106,6 +109,39 @@ struct VolumesArgs {
     filters: Vec<Filter>,
 }
 
+#[derive(Debug, Args)]
+struct ImagesArgs {
+    /// Only reap when the measured filesystem is at least this full (percent).
+    #[arg(long, value_name = "percent", default_value_t = 80, value_parser = parse_percent)]
+    threshold: u8,
+    /// Remove unused images (largest first) until disk usage falls below this (percent).
+    #[arg(long, value_name = "percent", default_value_t = 70, value_parser = parse_percent)]
+    target: u8,
+    /// Filesystem path to measure. Defaults to the docker daemon's root directory,
+    /// which is only correct when the daemon runs on this machine.
+    #[arg(long, value_name = "path")]
+    disk_path: Option<PathBuf>,
+    #[arg(
+        name = "filter",
+        long,
+        short = 'f',
+        help = "Only reap images matching a Docker Engine-supported filter (https://docs.docker.com/engine/reference/commandline/image_ls/#filter). Can be specified multiple times",
+        value_name = "name=value",
+        value_parser = parse_filter
+    )]
+    filters: Vec<Filter>,
+}
+
+fn parse_percent(value: &str) -> Result<u8, anyhow::Error> {
+    let percent: u8 = value
+        .parse()
+        .context("percentages must be integers between 1 and 100")?;
+    if !(1..=100).contains(&percent) {
+        anyhow::bail!("percentages must be between 1 and 100");
+    }
+    Ok(percent)
+}
+
 fn parse_filter(value: &str) -> Result<Filter, anyhow::Error> {
     let err_msg = "filters must be in NAME=VALUE(=VALUE) format";
     let (name, value) = value.split_once('=').context(err_msg)?;
@@ -132,6 +168,19 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt::init();
 
     let global_args = Cli::parse();
+
+    // Disk usage can only be measured on a local filesystem, so the default
+    // disk path (the daemon's root directory) is wrong for a remote daemon.
+    if let Commands::Images(ref args) = global_args.command
+        && args.disk_path.is_none()
+        && env::var("DOCKER_HOST").is_ok()
+    {
+        anyhow::bail!(
+            "DOCKER_HOST is set: pass --disk-path explicitly when targeting a remote daemon \
+             (the images subcommand measures a local filesystem)"
+        );
+    }
+
     let docker = {
         if env::var("DOCKER_CERT_PATH").is_ok() {
             debug!("Environment variable DOCKER_CERT_PATH set. Connecting via TLS");
@@ -186,6 +235,16 @@ async fn main() -> Result<(), anyhow::Error> {
                     filters: &args.filters,
                 };
                 reap_volumes(&docker, &config).await
+            }
+            Commands::Images(ref args) => {
+                let config = ReapImagesConfig {
+                    dry_run: global_args.dry_run,
+                    threshold: args.threshold,
+                    target: args.target,
+                    disk_path: args.disk_path.clone(),
+                    filters: &args.filters,
+                };
+                reap_images(&docker, &config).await
             }
         };
         match result {

--- a/src/reaper.rs
+++ b/src/reaper.rs
@@ -608,7 +608,7 @@ pub(crate) fn plan_image_evictions(
             unique_size: u64::try_from(image.size - image.shared_size.max(0)).unwrap_or(0),
         })
         .collect();
-    candidates.sort_by(|a, b| b.unique_size.cmp(&a.unique_size));
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.unique_size));
     candidates
 }
 

--- a/src/reaper.rs
+++ b/src/reaper.rs
@@ -1,15 +1,17 @@
 use bollard::Docker;
-use bollard::models::VolumeListResponse;
+use bollard::models::{ImageSummary, VolumeListResponse};
 use bollard::query_parameters::{
-    ListContainersOptions, ListNetworksOptions, ListVolumesOptions, RemoveContainerOptions,
+    ListContainersOptions, ListImagesOptions, ListNetworksOptions, ListVolumesOptions,
+    RemoveContainerOptions, RemoveImageOptions,
 };
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tabled::Tabled;
 use thiserror::Error;
 use tokio::time::Duration;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 #[derive(Debug)]
 pub(crate) struct ReapContainersConfig<'a> {
@@ -50,6 +52,21 @@ pub(crate) struct ReapVolumesConfig<'a> {
 }
 
 #[derive(Debug)]
+pub(crate) struct ReapImagesConfig<'a> {
+    /// Return results without actually removing images.
+    pub(crate) dry_run: bool,
+    /// Reap only when the measured filesystem is at least this full (percent).
+    pub(crate) threshold: u8,
+    /// Remove images (largest unique size first) until usage falls below this (percent).
+    pub(crate) target: u8,
+    /// Filesystem to measure; defaults to the daemon's root directory, which
+    /// is only correct when the daemon is local.
+    pub(crate) disk_path: Option<PathBuf>,
+    /// Additional Docker Engine-supported [image filters](https://docs.docker.com/engine/reference/commandline/image_ls/#filter).
+    pub(crate) filters: &'a Vec<Filter>,
+}
+
+#[derive(Debug)]
 pub(crate) enum RemovalStatus {
     /// Used in dry-run mode to indicate that a resource is eligible for removal.
     Eligible,
@@ -57,6 +74,11 @@ pub(crate) enum RemovalStatus {
     Success,
     /// Removal was already in progress.
     InProgress,
+    /// Resource was in use at removal time and skipped (e.g. a container was
+    /// created from an image between listing and removal).
+    InUse,
+    /// Resource was not needed to reach the disk usage target.
+    NotNeeded,
     /// An error occurred when attempting to remove this resource.
     Error(RemovalError),
 }
@@ -67,6 +89,8 @@ impl fmt::Display for RemovalStatus {
             Self::Eligible => write!(f, "Eligible for removal"),
             Self::Success => write!(f, "Removed"),
             &Self::InProgress => write!(f, "Removal in progress"),
+            Self::InUse => write!(f, "Skipped: in use"),
+            Self::NotNeeded => write!(f, "Skipped: target reached"),
             Self::Error(e) => write!(f, "Error: {}", e),
         }
     }
@@ -111,6 +135,7 @@ pub(crate) enum ResourceType {
     Container,
     Network,
     Volume,
+    Image,
 }
 
 impl fmt::Display for ResourceType {
@@ -125,6 +150,9 @@ impl fmt::Display for ResourceType {
             Self::Volume => {
                 write!(f, "Volume")
             }
+            Self::Image => {
+                write!(f, "Image")
+            }
         }
     }
 }
@@ -137,6 +165,8 @@ pub(crate) struct Resource {
     #[tabled(skip)]
     pub(crate) id: String,
     pub(crate) name: String,
+    /// Extra per-resource context (e.g. reclaimable size for images).
+    pub(crate) details: String,
     pub(crate) status: RemovalStatus,
 }
 
@@ -221,6 +251,33 @@ impl Resource {
                     Err(e) => self.status = RemovalStatus::Error(RemovalError::Docker(e)),
                 }
             }
+            ResourceType::Image => {
+                // No force: an image that gained a container reference since
+                // listing produces a 409 and is skipped rather than orphaning
+                // a running container's image.
+                let options = RemoveImageOptions {
+                    force: false,
+                    noprune: false,
+                    ..Default::default()
+                };
+                match docker.remove_image(&self.id, Some(options), None).await {
+                    Ok(_) => {
+                        self.status = RemovalStatus::Success;
+                    }
+                    Err(DockerResponseServerError {
+                        status_code: 404, ..
+                    }) => {
+                        // Mark as successful if already removed (404)
+                        self.status = RemovalStatus::Success;
+                    }
+                    Err(DockerResponseServerError {
+                        status_code: 409, ..
+                    }) => {
+                        self.status = RemovalStatus::InUse;
+                    }
+                    Err(e) => self.status = RemovalStatus::Error(RemovalError::Docker(e)),
+                }
+            }
         }
     }
 }
@@ -243,6 +300,12 @@ pub(crate) enum ReapError {
     TaskFailure(#[from] tokio::task::JoinError),
     #[error("min_age must be less than max_age")]
     InvalidAgeBound,
+    #[error("target must be less than threshold")]
+    InvalidDiskBounds,
+    #[error("failed to measure disk usage: {0}")]
+    DiskMeasurement(#[from] std::io::Error),
+    #[error("docker daemon did not report its root directory; pass --disk-path explicitly")]
+    UnknownDockerRoot,
 }
 
 pub(crate) async fn reap_containers(
@@ -315,6 +378,7 @@ pub(crate) async fn reap_containers(
                 .first()
                 .unwrap_or(&id)
                 .clone(),
+            details: String::new(),
             status: RemovalStatus::Eligible,
         });
         if config.reap_networks
@@ -333,6 +397,7 @@ pub(crate) async fn reap_containers(
             resource_type: ResourceType::Network,
             id: network_name.clone(),
             name: network_name.clone(),
+            details: String::new(),
             status: RemovalStatus::Eligible,
         })
     }
@@ -418,6 +483,7 @@ pub(crate) async fn reap_networks(
                 resource_type: ResourceType::Network,
                 id: name.clone(),
                 name,
+                details: String::new(),
                 status: RemovalStatus::Eligible,
             })
         })
@@ -497,6 +563,7 @@ pub(crate) async fn reap_volumes(
             resource_type: ResourceType::Volume,
             id: volume.name.clone(),
             name: volume.name,
+            details: String::new(),
             status: RemovalStatus::Eligible,
         })
         .collect();
@@ -509,4 +576,194 @@ pub(crate) async fn reap_volumes(
     });
     let removed_volumes = futures::future::join_all(volume_futures).await;
     Ok(removed_volumes)
+}
+
+/// An image eligible for eviction: referenced by no container, sized by the
+/// bytes uniquely attributable to it (i.e. not shared with other images).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ImageCandidate {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) unique_size: u64,
+}
+
+/// Selects and orders eviction candidates: images not referenced by any
+/// container, largest unique size first. Unique size (total minus layers
+/// shared with other images) is what a removal actually reclaims; an unknown
+/// shared size (-1) is treated as fully unique.
+pub(crate) fn plan_image_evictions(
+    images: &[ImageSummary],
+    in_use: &HashSet<String>,
+) -> Vec<ImageCandidate> {
+    let mut candidates: Vec<ImageCandidate> = images
+        .iter()
+        .filter(|image| !in_use.contains(&image.id))
+        .map(|image| ImageCandidate {
+            id: image.id.clone(),
+            name: image
+                .repo_tags
+                .first()
+                .cloned()
+                .unwrap_or_else(|| image.id.clone()),
+            unique_size: u64::try_from(image.size - image.shared_size.max(0)).unwrap_or(0),
+        })
+        .collect();
+    candidates.sort_by(|a, b| b.unique_size.cmp(&a.unique_size));
+    candidates
+}
+
+/// Used and total capacity (in bytes) of the filesystem containing `path`,
+/// computed like df(1): capacity is used space plus space available to
+/// unprivileged processes, so the root reserve never counts as free.
+fn disk_usage(path: &Path) -> Result<(u64, u64), ReapError> {
+    let vfs = rustix::fs::statvfs(path).map_err(std::io::Error::from)?;
+    let used = vfs.f_blocks.saturating_sub(vfs.f_bfree) * vfs.f_frsize;
+    let capacity = used + vfs.f_bavail * vfs.f_frsize;
+    if capacity == 0 {
+        return Err(ReapError::DiskMeasurement(std::io::Error::other(
+            "filesystem reports zero capacity",
+        )));
+    }
+    Ok((used, capacity))
+}
+
+fn used_percent(used: u64, capacity: u64) -> f64 {
+    100.0 * used as f64 / capacity as f64
+}
+
+fn format_size(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut size = bytes as f64;
+    let mut unit = 0;
+    while size >= 1024.0 && unit < UNITS.len() - 1 {
+        size /= 1024.0;
+        unit += 1;
+    }
+    format!("{:.1} {}", size, UNITS[unit])
+}
+
+pub(crate) async fn reap_images(
+    docker: &Docker,
+    config: &ReapImagesConfig<'_>,
+) -> Result<Vec<Resource>, ReapError> {
+    if config.target >= config.threshold {
+        return Err(ReapError::InvalidDiskBounds);
+    }
+
+    // Resolve the filesystem to measure: an explicit path, or the daemon's
+    // image store. The latter is only meaningful when the daemon is local —
+    // main.rs refuses the remote+default combination up front.
+    let disk_path = match &config.disk_path {
+        Some(path) => path.clone(),
+        None => PathBuf::from(
+            docker
+                .info()
+                .await?
+                .docker_root_dir
+                .ok_or(ReapError::UnknownDockerRoot)?,
+        ),
+    };
+
+    let (used, capacity) = disk_usage(&disk_path)?;
+    let usage = used_percent(used, capacity);
+    if usage < config.threshold as f64 {
+        info!(
+            "Disk usage of {} is {:.1}%, below the {}% threshold; nothing to do",
+            disk_path.display(),
+            usage,
+            config.threshold
+        );
+        return Ok(Vec::new());
+    }
+    warn!(
+        "Disk usage of {} is {:.1}%, at or above the {}% threshold; evicting images to reach {}%",
+        disk_path.display(),
+        usage,
+        config.threshold,
+        config.target
+    );
+
+    // An image referenced by any container — running or stopped — must not be
+    // removed, so collect the referenced image IDs first.
+    let in_use: HashSet<String> = docker
+        .list_containers(Some(ListContainersOptions {
+            all: true,
+            ..Default::default()
+        }))
+        .await?
+        .into_iter()
+        .filter_map(|container| container.image_id)
+        .collect();
+
+    // shared_size asks the engine to compute per-image shared layer bytes,
+    // which list_images otherwise reports as -1.
+    let images = docker
+        .list_images(Some(ListImagesOptions {
+            shared_size: true,
+            filters: Some(config.filters.to_bollard_filters()),
+            ..Default::default()
+        }))
+        .await?;
+
+    let candidates = plan_image_evictions(&images, &in_use);
+    let target_bytes = (config.target as u64) * (capacity / 100);
+
+    if config.dry_run {
+        // Estimate using unique sizes; actual reclaim is re-measured from the
+        // filesystem in a real run.
+        let mut projected_used = used;
+        return Ok(candidates
+            .into_iter()
+            .map(|candidate| {
+                let status = if projected_used > target_bytes {
+                    projected_used = projected_used.saturating_sub(candidate.unique_size);
+                    RemovalStatus::Eligible
+                } else {
+                    RemovalStatus::NotNeeded
+                };
+                Resource {
+                    resource_type: ResourceType::Image,
+                    id: candidate.id,
+                    name: candidate.name,
+                    details: format_size(candidate.unique_size),
+                    status,
+                }
+            })
+            .collect());
+    }
+
+    // Remove sequentially, largest first, re-measuring the filesystem after
+    // each successful removal so we stop as soon as the target is reached
+    // rather than trusting the shared-size estimates.
+    let mut results = Vec::new();
+    for candidate in candidates {
+        let (used, capacity) = disk_usage(&disk_path)?;
+        if used <= target_bytes {
+            info!(
+                "Disk usage now {:.1}%, at or below the {}% target",
+                used_percent(used, capacity),
+                config.target
+            );
+            break;
+        }
+        let mut resource = Resource {
+            resource_type: ResourceType::Image,
+            id: candidate.id,
+            name: candidate.name,
+            details: format_size(candidate.unique_size),
+            status: RemovalStatus::Eligible,
+        };
+        resource.remove(docker).await;
+        results.push(resource);
+    }
+
+    let (used, capacity) = disk_usage(&disk_path)?;
+    if used > target_bytes {
+        warn!(
+            "Out of removable images with disk usage still at {:.1}% (target {}%)",
+            used_percent(used, capacity),
+            config.target
+        );
+    }
+    Ok(results)
 }

--- a/src/tests/containers.rs
+++ b/src/tests/containers.rs
@@ -166,12 +166,14 @@ async fn dry_run() {
         resource_type: ResourceType::Container,
         id: container_id.clone(),
         name: String::new(),
+        details: String::new(),
         status: RemovalStatus::Eligible,
     }));
     assert!(result.contains(&Resource {
         resource_type: ResourceType::Network,
         id: network_id.clone().expect("network ID not present"),
         name: String::new(),
+        details: String::new(),
         status: RemovalStatus::Eligible,
     }));
     assert_eq!(

--- a/src/tests/images.rs
+++ b/src/tests/images.rs
@@ -1,0 +1,71 @@
+//! Unit tests for image eviction planning.
+//!
+//! Unlike the other resource types, these do not run against a live Docker
+//! daemon: an integration test would have to delete the host's real images
+//! (eligibility depends on global disk usage, which a test cannot safely
+//! manufacture). The docker-facing plumbing reuses the same list/remove
+//! patterns as the other subcommands; the eviction policy is pure and tested
+//! here.
+
+use crate::reaper::{ImageCandidate, plan_image_evictions};
+use bollard::models::ImageSummary;
+use std::collections::HashSet;
+
+fn image(id: &str, tag: Option<&str>, size: i64, shared_size: i64) -> ImageSummary {
+    ImageSummary {
+        id: id.to_string(),
+        repo_tags: tag.map(|t| vec![t.to_string()]).unwrap_or_default(),
+        size,
+        shared_size,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn images_in_use_are_protected() {
+    let images = vec![
+        image("sha256:aaa", Some("challenge-a:1"), 500, 0),
+        image("sha256:bbb", Some("challenge-b:1"), 100, 0),
+    ];
+    let in_use = HashSet::from(["sha256:aaa".to_string()]);
+    let plan = plan_image_evictions(&images, &in_use);
+    assert_eq!(
+        plan,
+        vec![ImageCandidate {
+            id: "sha256:bbb".to_string(),
+            name: "challenge-b:1".to_string(),
+            unique_size: 100,
+        }]
+    );
+}
+
+#[test]
+fn largest_unique_size_evicted_first() {
+    // bbb is the largest by total size, but most of it is shared layers;
+    // aaa reclaims the most when removed and must come first.
+    let images = vec![
+        image("sha256:ccc", Some("c:1"), 50, 0),
+        image("sha256:bbb", Some("b:1"), 1000, 940),
+        image("sha256:aaa", Some("a:1"), 400, 100),
+    ];
+    let plan = plan_image_evictions(&images, &HashSet::new());
+    let order: Vec<&str> = plan.iter().map(|c| c.id.as_str()).collect();
+    assert_eq!(order, vec!["sha256:aaa", "sha256:bbb", "sha256:ccc"]);
+    assert_eq!(plan[0].unique_size, 300);
+    assert_eq!(plan[1].unique_size, 60);
+}
+
+#[test]
+fn unknown_shared_size_treated_as_fully_unique() {
+    // The API reports -1 when shared size was not computed.
+    let images = vec![image("sha256:aaa", Some("a:1"), 400, -1)];
+    let plan = plan_image_evictions(&images, &HashSet::new());
+    assert_eq!(plan[0].unique_size, 400);
+}
+
+#[test]
+fn untagged_images_fall_back_to_id() {
+    let images = vec![image("sha256:aaa", None, 400, 0)];
+    let plan = plan_image_evictions(&images, &HashSet::new());
+    assert_eq!(plan[0].name, "sha256:aaa");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod common;
 mod containers;
+mod images;
 mod networks;
 mod volumes;

--- a/src/tests/networks.rs
+++ b/src/tests/networks.rs
@@ -110,6 +110,7 @@ async fn dry_run() {
         resource_type: ResourceType::Network,
         id: network_id.clone(),
         name: String::new(),
+        details: String::new(),
         status: RemovalStatus::Eligible
     }));
     assert_eq!(network_exists(&network_id).await, true);

--- a/src/tests/volumes.rs
+++ b/src/tests/volumes.rs
@@ -110,6 +110,7 @@ async fn dry_run() {
         resource_type: ResourceType::Volume,
         id: volume_id.clone(),
         name: String::new(),
+        details: String::new(),
         status: RemovalStatus::Eligible
     }));
     assert_eq!(volume_exists(&volume_id).await, true);


### PR DESCRIPTION
Removes unreferenced images largest-reclaimable-first when disk usage exceeds a threshold (default 80%), stopping at a target (default 70%). Non-forced removals skip images that gain containers mid-run.